### PR TITLE
bump package version

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - git: "https://github.com/bcodell/dbt-activity-schema.git"
-    revision: "v0.1.0"
+    revision: v0.1.1


### PR DESCRIPTION
Resolves https://github.com/patricktrainer/activity_schema_demo/issues/1

This PR bumps the package dependency to version `0.1.1`, which resolves the issue linked above.